### PR TITLE
Make MCP POST handler stateless so the server works on serverless/isolate hosts (Deno Deploy)

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,160 @@
+# SETUP: Connecting the Google Tasks MCP Server to the Claude App
+
+This runbook covers everything needed to deploy this server to Deno Deploy and connect it to the Claude app (claude.ai) as a custom connector.
+
+It is written for a single user (personal) deployment. Where a step requires your own Google or Deno login, it is called out explicitly.
+
+The MCP server is remote, served over HTTP plus SSE at the /mcp endpoint with bearer auth. It implements OAuth discovery at /.well-known/oauth-authorization-server, an authorization endpoint at /authorize, and a callback at /callback. The OAuth scope used is https://www.googleapis.com/auth/tasks.
+
+## Overview of what you will do
+
+1. Enable the Google Tasks API in Google Cloud Console.
+2. Configure the OAuth consent screen (External), add yourself as a test user, and add the tasks scope.
+3. Create a Web application OAuth client and set its authorized redirect URI.
+4. Deploy this repo to Deno Deploy and set the environment variables.
+5. Update the Google OAuth client redirect URI to your live domain.
+6. Add the custom connector in the Claude app and authorize it.
+
+Throughout this document, replace YOUR_DEPLOYED_DOMAIN with your actual Deno Deploy domain (for example, google-tasks-mcp.deno.dev).
+
+## Prerequisites
+
+A Google account that has Google Tasks. A Deno Deploy account (sign in with GitHub at https://dash.deno.com). The forked repository connected to Deno Deploy, or the Deno CLI installed locally if you prefer deploying with deployctl.
+
+## Step 1: Enable the Google Tasks API
+
+1. Go to the Google Cloud Console: https://console.cloud.google.com
+2. Create a new project (or select an existing one). A simple name like "google-tasks-mcp" is fine.
+3. In the left navigation, open APIs and Services, then Library.
+4. Search for "Google Tasks API" and open it.
+5. Click Enable.
+
+## Step 2: Configure the OAuth consent screen
+
+1. In APIs and Services, open OAuth consent screen.
+2. Choose User Type: External. (External is required because this is not a Google Workspace internal app; it still works for personal single-user use.)
+3. Click Create, then fill in the required fields:
+   - App name: Google Tasks MCP (or any name you prefer).
+   - User support email: your email.
+   - Developer contact email: your email.
+4. On the Scopes step, click Add or Remove Scopes, then add this scope: https://www.googleapis.com/auth/tasks
+   (If it is not in the filtered list, paste it into the "Manually add scopes" box, click Add to Table, then Update.)
+5. On the Test users step, click Add Users and add the Google account you will use with Claude. This must be the same account you authorize later.
+6. Save and continue to the summary.
+
+### GOTCHA: the 7 day refresh token expiry in testing mode (read this)
+
+While the OAuth consent screen is left in "Testing" publishing status, Google expires the refresh token after 7 days. That forces you to re-authorize the connector roughly once a week, which is annoying for a personal always-on connector.
+
+Recommendation for single-user personal use: publish the consent screen to production to avoid the weekly re-auth.
+
+To do this, go to APIs and Services, OAuth consent screen, and click Publish App (move publishing status from Testing to In production). For a single sensitive scope like Google Tasks used only by you, Google typically does not require full verification for the app to function, although the consent screen may show an "unverified app" warning that you can click through (Advanced, then "Go to App"). Verification is generally only mandatory if you intend to distribute the app to many external users. Since this is your own personal connector, publishing to production removes the 7 day token expiry without needing a formal verification review for personal use.
+
+If you would rather not publish, you can leave it in Testing, but expect to click Connect again in Claude about every 7 days.
+
+## Step 3: Create the Web application OAuth client
+
+1. In APIs and Services, open Credentials.
+2. Click Create Credentials, then OAuth client ID.
+3. Application type: Web application.
+4. Name: google-tasks-mcp web client (or any name).
+5. Under Authorized redirect URIs, click Add URI and enter:
+   https://YOUR_DEPLOYED_DOMAIN/callback
+   (You may not know the exact domain until after Step 4. You can either deploy first and come back, or set a placeholder now and edit it in Step 5.)
+6. Click Create.
+7. Copy the Client ID and Client Secret. You will paste these into Deno Deploy as GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET.
+
+Note: The redirect URI in Google must match GOOGLE_REDIRECT_URI exactly, including https and the /callback path.
+
+## Step 4: Deploy to Deno Deploy
+
+The entry point compiles from src/index.ts to build/index.js (see tsconfig.json, outDir build). The compiled module exports a default object with a fetch handler, which is exactly the format Deno Deploy expects:
+
+    export default { fetch: app.fetch };
+
+The server also serves static files from the public directory (the landing page, privacy policy, and favicon), so the public folder must be included in the deployment.
+
+You can deploy either from the Deno Deploy dashboard (recommended, no local toolchain needed) or with the deployctl CLI.
+
+### Option A: Deno Deploy dashboard (GitHub integration)
+
+1. Go to https://dash.deno.com and sign in with GitHub.
+2. Click New Project.
+3. Select your forked repository: Gabriel-Dalton/google-tasks-mcp.
+4. For the entry point, set: build/index.js
+   Important: build/ is gitignored, so it is not in the repo. Either:
+   (a) Configure the project to run the build step. In the project Build settings, set the install step to "npm install" and the build command to "npm run build" so Deno Deploy produces build/index.js before serving; or
+   (b) Use the Deno-native entry point src/index.ts directly. Because tsconfig uses rewriteRelativeImportExtensions and the source already uses .ts import specifiers, Deno can run src/index.ts without a separate tsc step. If you choose this, set the entry point to src/index.ts and skip the build command.
+5. Set the environment variables (see the table in Step 4c) in the project Settings, Environment Variables.
+6. Deploy. Note the production URL Deno assigns (for example https://google-tasks-mcp.deno.dev). That is your YOUR_DEPLOYED_DOMAIN.
+
+### Option B: deployctl CLI (local)
+
+This requires the Deno CLI and a Deno Deploy access token, and it requires your Deno login. Do not paste your token into this document or any web form.
+
+    # Install deno (if not installed), then build and deploy
+    npm install
+    npm run build
+    deployctl deploy --project=google-tasks-mcp --include=build,public build/index.js
+
+The --include=build,public flag ensures both the compiled entry point and the static public assets are uploaded. After deploying, set the environment variables in the dashboard (deployctl can also set them with --env or --env-file, but never commit a file containing real secrets).
+
+### Step 4c: Environment variables to set in Deno Deploy
+
+Set these in Deno Deploy under Project Settings, Environment Variables:
+
+| Variable | Required | Value to use |
+| --- | --- | --- |
+| GOOGLE_CLIENT_ID | Yes | The Client ID from Step 3. |
+| GOOGLE_CLIENT_SECRET | Yes | The Client Secret from Step 3. |
+| GOOGLE_REDIRECT_URI | Yes | https://YOUR_DEPLOYED_DOMAIN/callback (must match the Google redirect URI exactly). |
+| ENCRYPTION_SECRET | Yes | A 32+ character random secret. Generate locally with: npm run generate-secret (it prints a line beginning with ENCRYPTION_SECRET=; use only the hex value after the equals sign). |
+| ALLOWED_ORIGINS | Recommended | https://claude.ai |
+| PORT | No | Leave unset on Deno Deploy (it uses the fetch handler, not a port). Useful only for local runs (default 3000). |
+| LOG_LEVEL | No | info (or debug while troubleshooting). |
+
+Keep ENCRYPTION_SECRET stable across restarts. If it changes, previously stored encrypted tokens can no longer be decrypted and you will have to re-authorize.
+
+## Step 5: Update the Google OAuth redirect URI
+
+Once you know your live domain from Step 4, go back to Google Cloud Console, APIs and Services, Credentials, open your Web application OAuth client, and make sure Authorized redirect URIs contains exactly:
+
+    https://YOUR_DEPLOYED_DOMAIN/callback
+
+Confirm it matches the GOOGLE_REDIRECT_URI environment variable in Deno Deploy. Save.
+
+You can sanity check the deployment by visiting:
+
+    https://YOUR_DEPLOYED_DOMAIN/.well-known/oauth-authorization-server
+
+It should return a JSON document describing the issuer, authorization_endpoint (/authorize), token_endpoint (/token), and mcp_endpoint (/mcp).
+
+## Step 6: Add the custom connector in the Claude app
+
+1. Open the Claude app (claude.ai or the desktop app).
+2. Go to Settings.
+3. Open Connectors.
+4. Click Add custom connector.
+5. Fill in:
+   - Name: Google Tasks (or any name you prefer).
+   - Remote MCP server URL: https://YOUR_DEPLOYED_DOMAIN/mcp
+6. Click Add.
+7. Find the new connector and click Connect.
+8. A browser window opens with the Google authorization page. Sign in with the same Google account you added as a test user (or that owns the published app), and approve the Google Tasks permission.
+9. You are redirected back and the connection completes.
+
+After connecting, you can ask Claude things like "What task lists do I have?" or "Add a task to my Work list due Friday."
+
+## Troubleshooting
+
+If the Google consent screen shows "access blocked" or "app not verified": confirm your Google account is listed as a test user (Testing mode), or that the app is published to production. The unverified warning can be bypassed for your own account via Advanced, then Go to App.
+
+If Claude cannot connect or CORS errors appear: confirm ALLOWED_ORIGINS includes https://claude.ai exactly (no trailing slash), and that the discovery URL returns valid JSON.
+
+If you must re-authorize every week: your consent screen is still in Testing mode. Publish to production (see the gotcha in Step 2).
+
+If tokens stop working after a redeploy: confirm ENCRYPTION_SECRET did not change between deployments.
+
+## Security notes
+
+Never commit real secrets. The .env file is listed in .gitignore (alongside build/ and node_modules/), so a local .env will not be tracked. Keep .env.example with placeholder values only.

--- a/public/index.html
+++ b/public/index.html
@@ -1,218 +1,78 @@
 <!DOCTYPE html>
-<html lang="en">
-<head>
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-VH4K1SC8QC"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-VH4K1SC8QC');
-    </script>
-
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Google Tasks MCP Server</title>
-    <style>
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-            min-height: 100vh;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            padding: 20px;
-        }
-        .container {
-            max-width: 800px;
-            background: white;
-            border-radius: 16px;
-            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
-            padding: 60px 40px;
-            text-align: center;
-        }
-        .logo {
-            font-size: 4em;
-            margin-bottom: 20px;
-        }
-        h1 {
-            color: #667eea;
-            margin-bottom: 10px;
-            font-size: 2.5em;
-        }
-        .tagline {
-            color: #666;
-            font-size: 1.2em;
-            margin-bottom: 40px;
-        }
-        .description {
-            color: #555;
-            margin-bottom: 40px;
-            text-align: left;
-            line-height: 1.8;
-        }
-        .features {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-            gap: 20px;
-            margin-bottom: 40px;
-            text-align: left;
-        }
-        .feature {
-            padding: 20px;
-            background: #f8f9fa;
-            border-radius: 8px;
-            border-left: 4px solid #667eea;
-        }
-        .feature-icon {
-            font-size: 2em;
-            margin-bottom: 10px;
-        }
-        .feature h3 {
-            color: #667eea;
-            margin-bottom: 8px;
-            font-size: 1.1em;
-        }
-        .feature p {
-            color: #666;
-            font-size: 0.9em;
-        }
-        .buttons {
-            display: flex;
-            gap: 15px;
-            justify-content: center;
-            flex-wrap: wrap;
-            margin-bottom: 30px;
-        }
-        .btn {
-            display: inline-block;
-            padding: 14px 32px;
-            border-radius: 8px;
-            text-decoration: none;
-            font-weight: 600;
-            transition: all 0.3s ease;
-            font-size: 1em;
-        }
-        .btn-primary {
-            background: #667eea;
-            color: white;
-        }
-        .btn-primary:hover {
-            background: #5568d3;
-            transform: translateY(-2px);
-            box-shadow: 0 8px 20px rgba(102, 126, 234, 0.4);
-        }
-        .btn-secondary {
-            background: white;
-            color: #667eea;
-            border: 2px solid #667eea;
-        }
-        .btn-secondary:hover {
-            background: #f8f9fa;
-            transform: translateY(-2px);
-        }
-        .status {
-            display: inline-block;
-            padding: 8px 16px;
-            background: #10b981;
-            color: white;
-            border-radius: 20px;
-            font-size: 0.9em;
-            font-weight: 600;
-            margin-bottom: 30px;
-        }
-        .footer {
-            margin-top: 40px;
-            padding-top: 20px;
-            border-top: 1px solid #e5e7eb;
-            color: #666;
-            font-size: 0.9em;
-        }
-        .footer a {
-            color: #667eea;
-            text-decoration: none;
-        }
-        .footer a:hover {
-            text-decoration: underline;
-        }
-        code {
-            background: #f8f9fa;
-            padding: 2px 8px;
-            border-radius: 4px;
-            font-family: 'Courier New', monospace;
-            color: #667eea;
-            font-size: 0.9em;
-        }
-    </style>
-</head>
+<html lang="en"><head><meta charset="UTF-8"/><meta name="viewport" content="width=device-width, initial-scale=1.0"/><title>Google Tasks MCP Server</title><link rel="icon" href="/favicon.ico"/><meta name="description" content="An open source MCP server that lets AI assistants manage your Google Tasks through natural language."/>
+<style>
+  :root{--bg:#0b0d12;--surface:#12151c;--surface-2:#171b24;--border:#232936;--text:#e7eaf0;--muted:#9aa3b2;--accent:#6c7bff;--accent-2:#4f46e5;--green:#2bd47d;--radius:14px;--maxw:1040px;}
+  *{box-sizing:border-box;margin:0;padding:0;}
+  html{scroll-behavior:smooth;}
+  body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Helvetica,Arial,sans-serif;background:radial-gradient(1200px 600px at 50% -200px,#1b2030 0%,var(--bg) 60%);color:var(--text);line-height:1.6;-webkit-font-smoothing:antialiased;min-height:100vh;}
+  a{color:inherit;text-decoration:none;}
+  code{font-family:"SF Mono",ui-monospace,"JetBrains Mono",Menlo,Consolas,monospace;font-size:0.86em;}
+  .wrap{max-width:var(--maxw);margin:0 auto;padding:0 24px;}
+  header.nav{position:sticky;top:0;z-index:10;backdrop-filter:saturate(140%) blur(10px);background:rgba(11,13,18,0.7);border-bottom:1px solid var(--border);}
+  .nav-inner{display:flex;align-items:center;justify-content:space-between;height:64px;}
+  .brand{display:flex;align-items:center;gap:10px;font-weight:650;letter-spacing:-0.01em;}
+  .brand .logo{width:30px;height:30px;border-radius:8px;background:linear-gradient(135deg,var(--accent),var(--accent-2));display:grid;place-items:center;color:#fff;font-weight:800;font-size:16px;}
+  .nav-links{display:flex;gap:22px;align-items:center;}
+  .nav-links a{color:var(--muted);font-size:14px;font-weight:500;transition:color .15s;}
+  .nav-links a:hover{color:var(--text);}
+  .btn{display:inline-flex;align-items:center;gap:8px;background:linear-gradient(135deg,var(--accent),var(--accent-2));color:#fff;font-weight:600;font-size:14px;padding:9px 16px;border-radius:10px;transition:transform .12s,box-shadow .12s;box-shadow:0 6px 20px -8px rgba(108,123,255,0.7);}
+  .btn:hover{transform:translateY(-1px);}
+  .btn.secondary{background:var(--surface-2);border:1px solid var(--border);box-shadow:none;color:var(--text);}
+  .hero{text-align:center;padding:96px 0 64px;}
+  .pill{display:inline-flex;align-items:center;gap:8px;background:rgba(43,212,125,0.12);color:var(--green);border:1px solid rgba(43,212,125,0.3);padding:6px 14px;border-radius:999px;font-size:13px;font-weight:600;margin-bottom:26px;}
+  .dot{width:8px;height:8px;border-radius:50%;background:var(--green);box-shadow:0 0 0 4px rgba(43,212,125,0.18);}
+  .hero h1{font-size:clamp(40px,6vw,62px);line-height:1.05;letter-spacing:-0.03em;font-weight:800;background:linear-gradient(180deg,#fff 0%,#c5cbe0 100%);-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;}
+  .hero .tagline{color:var(--muted);font-size:clamp(17px,2.4vw,21px);margin-top:18px;font-weight:500;}
+  .hero .lead{color:var(--muted);max-width:620px;margin:22px auto 34px;font-size:16px;}
+  .hero-actions{display:flex;gap:14px;justify-content:center;flex-wrap:wrap;}
+  .section{padding:56px 0;}
+  .section-title{font-size:13px;text-transform:uppercase;letter-spacing:0.12em;color:var(--muted);font-weight:700;margin-bottom:28px;text-align:center;}
+  .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:18px;}
+  .card{background:linear-gradient(180deg,var(--surface) 0%,var(--surface-2) 100%);border:1px solid var(--border);border-radius:var(--radius);padding:26px;transition:transform .15s,border-color .15s;}
+  .card:hover{transform:translateY(-3px);border-color:#2f3850;}
+  .card .ico{width:44px;height:44px;border-radius:11px;display:grid;place-items:center;background:rgba(108,123,255,0.12);border:1px solid rgba(108,123,255,0.25);margin-bottom:16px;}
+  .card .ico svg{width:22px;height:22px;stroke:var(--accent);fill:none;stroke-width:2;}
+  .card h3{font-size:17px;font-weight:650;margin-bottom:8px;letter-spacing:-0.01em;}
+  .card p{color:var(--muted);font-size:14.5px;}
+  .tools{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:30px;}
+  .tools h2{font-size:20px;font-weight:700;letter-spacing:-0.02em;margin-bottom:6px;}
+  .tools .sub{color:var(--muted);font-size:14px;margin-bottom:22px;}
+  .tools ul{list-style:none;display:grid;grid-template-columns:repeat(auto-fill,minmax(180px,1fr));gap:10px;}
+  .tools li{background:var(--surface-2);border:1px solid var(--border);border-radius:9px;padding:10px 12px;font-size:13px;color:var(--text);display:flex;align-items:center;gap:8px;}
+  .tools li::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--accent);flex:none;}
+  footer{border-top:1px solid var(--border);padding:40px 0;text-align:center;color:var(--muted);font-size:13.5px;}
+  footer .links{display:flex;gap:20px;justify-content:center;margin-bottom:14px;flex-wrap:wrap;}
+  footer .links a{color:var(--muted);transition:color .15s;}
+  footer .links a:hover{color:var(--text);}
+  footer .fine{font-size:12px;opacity:0.75;margin-top:8px;}
+  @media(max-width:640px){.nav-links a:not(.btn){display:none;}.hero{padding:64px 0 40px;}}
+</style></head>
 <body>
-    <div class="container">
-        <div class="logo">✓</div>
-        <h1>Google Tasks MCP Server</h1>
-        <p class="tagline">AI-Powered Task Management via Model Context Protocol</p>
-
-        <div class="status">🟢 Service Online</div>
-
-        <div class="description">
-            <p>
-                An open-source MCP server that enables AI assistants like Claude to seamlessly manage your Google Tasks through natural language.
-                Create, update, organize, and complete tasks without leaving your conversation.
-            </p>
-        </div>
-
-        <div class="features">
-            <div class="feature">
-                <div class="feature-icon">🤖</div>
-                <h3>AI Integration</h3>
-                <p>Connect with Claude Desktop or any MCP-compatible client</p>
-            </div>
-            <div class="feature">
-                <div class="feature-icon">🔒</div>
-                <h3>Secure & Private</h3>
-                <p>AES-256 encryption, privacy-safe logging, open source</p>
-            </div>
-            <div class="feature">
-                <div class="feature-icon">⚡</div>
-                <h3>Full API Coverage</h3>
-                <p>14 tools covering all Google Tasks API operations</p>
-            </div>
-            <div class="feature">
-                <div class="feature-icon">🌐</div>
-                <h3>OAuth 2.0</h3>
-                <p>Secure authentication with Google's official OAuth flow</p>
-            </div>
-        </div>
-
-        <div class="buttons">
-            <a href="https://github.com/akutishevsky/google-tasks-mcp" class="btn btn-primary" target="_blank">
-                View on GitHub
-            </a>
-            <a href="/privacy-policy" class="btn btn-secondary">
-                Privacy Policy
-            </a>
-        </div>
-
-        <div class="footer">
-            <p>
-                <strong>Available Tools:</strong> list_task_lists, get_task_list, insert_task_list, update_task_list, patch_task_list, delete_task_list,
-                list_tasks, get_task, insert_task, update_task, patch_task, delete_task, clear_completed_tasks, move_task
-            </p>
-            <p style="margin-top: 15px;">
-                Built with ❤️ using <a href="https://modelcontextprotocol.io" target="_blank">Model Context Protocol</a> ·
-                Licensed under <a href="https://opensource.org/licenses/MIT" target="_blank">MIT</a>
-            </p>
-            <p style="margin-top: 10px; font-size: 0.85em;">
-                Not affiliated with Google LLC or Anthropic PBC
-            </p>
-        </div>
-    </div>
-</body>
-</html>
+<header class="nav"><div class="wrap nav-inner"><div class="brand"><span class="logo">T</span> Google Tasks MCP</div><nav class="nav-links"><a href="#features">Features</a><a href="#tools">Tools</a><a href="/privacy-policy">Privacy</a><a class="btn secondary" href="https://github.com/akutishevsky/google-tasks-mcp" target="_blank" rel="noopener">GitHub</a></nav></div></header>
+<main>
+<section class="hero"><div class="wrap"><span class="pill"><span class="dot"></span> Service Online</span><h1>Google Tasks MCP Server</h1><p class="tagline">Task management for AI assistants via the Model Context Protocol</p><p class="lead">An open source MCP server that lets AI assistants like Claude manage your Google Tasks through natural language. Create, update, organize, and complete tasks without leaving the conversation.</p><div class="hero-actions"><a class="btn" href="https://github.com/akutishevsky/google-tasks-mcp" target="_blank" rel="noopener">View on GitHub</a><a class="btn secondary" href="#tools">Browse the tools</a></div></div></section>
+<section class="section" id="features"><div class="wrap"><p class="section-title">Why this server</p><div class="grid">
+<div class="card"><div class="ico"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 3v4M12 17v4M3 12h4M17 12h4"/></svg></div><h3>AI Integration</h3><p>Connect with Claude or any MCP compatible client over a remote HTTP and SSE endpoint.</p></div>
+<div class="card"><div class="ico"><svg viewBox="0 0 24 24"><rect x="4" y="11" width="16" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/></svg></div><h3>Secure and Private</h3><p>AES-256 encryption for stored tokens, privacy-safe logging, and fully open source.</p></div>
+<div class="card"><div class="ico"><svg viewBox="0 0 24 24"><path d="M13 2 4 14h7l-1 8 9-12h-7l1-8z"/></svg></div><h3>Full API Coverage</h3><p>14 tools covering every Google Tasks API operation, from task lists to individual tasks.</p></div>
+<div class="card"><div class="ico"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a15 15 0 0 1 0 18M12 3a15 15 0 0 0 0 18"/></svg></div><h3>OAuth 2.0</h3><p>Secure authentication through Google's official OAuth flow with discovery endpoints.</p></div>
+</div></div></section>
+<section class="section" id="tools"><div class="wrap"><div class="tools"><h2>Available tools</h2><p class="sub">14 tools covering all Google Tasks API operations.</p><ul>
+        <li><code>list_task_lists</code></li>
+        <li><code>get_task_list</code></li>
+        <li><code>insert_task_list</code></li>
+        <li><code>update_task_list</code></li>
+        <li><code>patch_task_list</code></li>
+        <li><code>delete_task_list</code></li>
+        <li><code>list_tasks</code></li>
+        <li><code>get_task</code></li>
+        <li><code>insert_task</code></li>
+        <li><code>update_task</code></li>
+        <li><code>patch_task</code></li>
+        <li><code>delete_task</code></li>
+        <li><code>clear_completed_tasks</code></li>
+        <li><code>move_task</code></li>
+</ul></div></div></section>
+</main>
+<footer><div class="wrap"><div class="links"><a href="https://github.com/akutishevsky/google-tasks-mcp" target="_blank" rel="noopener">GitHub</a><a href="/privacy-policy">Privacy Policy</a><a href="https://modelcontextprotocol.io" target="_blank" rel="noopener">Model Context Protocol</a><a href="https://opensource.org/licenses/MIT" target="_blank" rel="noopener">MIT License</a></div><p>Built with the Model Context Protocol. Licensed under MIT.</p><p class="fine">Not affiliated with Google LLC or Anthropic.</p></div></footer>
+</body></html>

--- a/src/server/mcp-endpoints.ts
+++ b/src/server/mcp-endpoints.ts
@@ -1,28 +1,79 @@
 import { Context } from "hono";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
-import { HonoSSETransport, sessionManager } from "../transport/mcp-transport.ts";
+import { HonoSSETransport } from "../transport/mcp-transport.ts";
 import { registerAllTools } from "../tools/index.ts";
 import { createLogger } from "../utils/logger.ts";
 
 const logger = createLogger({ component: "mcp-endpoints" });
 
-export async function handleMcpGet(c: Context) {
-  const sessionId = c.req.header("Mcp-Session-Id") || crypto.randomUUID();
-  const mcpAccessToken = c.get("mcpToken") as string;
+// Deno Deploy runs each request in a potentially different isolate, so MCP
+// session state cannot be shared in process memory across requests. The
+// server therefore operates in a stateless mode: every POST is fully
+// self contained. For each incoming JSON-RPC message we spin up a fresh
+// McpServer and transport, handle the single message, stream the response
+// back on the same HTTP response, and then close the stream.
 
-  const existingSession = sessionManager.getSession(sessionId);
-  if (existingSession) {
-    logger.info("Closing existing MCP session to establish new connection");
-    await existingSession.transport.close();
-    sessionManager.deleteSession(sessionId);
+export function handleMcpGet(c: Context) {
+  // In stateless mode there is no long lived server initiated stream to
+  // resume, so a GET simply opens an empty SSE stream that stays quiet.
+  // Clients that probe GET will keep the connection idle without errors.
+  const { readable, writable } = new TransformStream();
+  const writer = writable.getWriter();
+  const encoder = new TextEncoder();
+
+  const heartbeat = setInterval(() => {
+    writer.write(encoder.encode(": ping\n\n")).catch(() => {
+      clearInterval(heartbeat);
+    });
+  }, 15000);
+
+  c.req.raw.signal.addEventListener("abort", () => {
+    clearInterval(heartbeat);
+    writer.close().catch(() => {});
+  });
+
+  const headers = {
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    "Connection": "keep-alive",
+    "X-Accel-Buffering": "no",
+  };
+
+  return new Response(readable, { headers });
+}
+
+export async function handleMcpPost(c: Context) {
+  const mcpToken = c.get("mcpToken") as string;
+
+  let message: JSONRPCMessage;
+  try {
+    message = await c.req.json() as JSONRPCMessage;
+  } catch {
+    logger.error("Failed to parse incoming MCP message");
+    return c.json({
+      error: "invalid_request",
+      error_description: "Request body is not valid JSON",
+    }, 400);
   }
 
   const { readable, writable } = new TransformStream();
   const writer = writable.getWriter();
   const encoder = new TextEncoder();
+  let streamClosed = false;
+
+  const closeStream = () => {
+    if (streamClosed) {
+      return;
+    }
+    streamClosed = true;
+    writer.close().catch(() => {});
+  };
 
   const writeSSE = async (data: string, event?: string) => {
+    if (streamClosed) {
+      return;
+    }
     try {
       if (event) {
         await writer.write(encoder.encode(`event: ${event}\n`));
@@ -37,9 +88,13 @@ export async function handleMcpGet(c: Context) {
   transport.attachStream({
     writeSSE: async (data: { data: string; event?: string; id?: string }) => {
       await writeSSE(data.data, data.event);
+      // Each request expects a single response message. Once it has been
+      // written, close the stream so the client receives a complete reply
+      // instead of waiting on an open connection.
+      closeStream();
     },
     close: () => {
-      writer.close();
+      closeStream();
     },
   });
 
@@ -54,169 +109,37 @@ export async function handleMcpGet(c: Context) {
           capabilities: {
             tools: {},
           },
-        }
+        },
       );
 
-      registerAllTools(sessionServer, mcpAccessToken);
+      registerAllTools(sessionServer, mcpToken);
 
-      try {
-        await sessionServer.connect(transport);
+      await sessionServer.connect(transport);
+      logger.info("MCP request handled statelessly via POST");
 
-        sessionManager.createSession(sessionId, transport);
-        logger.info("MCP session established via GET");
+      await transport.handleIncomingMessage(message);
 
-        c.req.raw.signal.addEventListener("abort", () => {
-          logger.info("MCP connection closed by client");
-          sessionManager.deleteSession(sessionId);
-        });
-
-        const heartbeat = setInterval(async () => {
-          try {
-            await writeSSE("", "ping");
-          } catch {
-            clearInterval(heartbeat);
-          }
-        }, 15000);
-
-        c.req.raw.signal.addEventListener("abort", () => {
-          clearInterval(heartbeat);
-          sessionManager.deleteSession(sessionId);
-        });
-
-      } catch {
-        logger.error("Failed to connect MCP server to transport");
-        sessionManager.deleteSession(sessionId);
-        writer.close();
-      }
+      // Notifications and responses without a reply will not trigger a
+      // write, so close the stream after a short delay to avoid hanging.
+      setTimeout(() => {
+        closeStream();
+      }, 1000);
     } catch {
-      logger.error("Failed to initialize MCP session");
-      writer.close();
+      logger.error("Failed to handle MCP message via POST");
+      closeStream();
     }
   })();
+
+  c.req.raw.signal.addEventListener("abort", () => {
+    closeStream();
+  });
 
   const headers = {
     "Content-Type": "text/event-stream",
     "Cache-Control": "no-cache",
     "Connection": "keep-alive",
     "X-Accel-Buffering": "no",
-    "Mcp-Session-Id": sessionId,
   };
 
   return new Response(readable, { headers });
-}
-
-export async function handleMcpPost(c: Context) {
-  let sessionId = c.req.header("Mcp-Session-Id");
-  const mcpToken = c.get("mcpToken") as string;
-
-  if (!sessionId) {
-    sessionId = crypto.randomUUID();
-    const message = await c.req.json() as JSONRPCMessage;
-
-    const { readable, writable } = new TransformStream();
-    const writer = writable.getWriter();
-    const encoder = new TextEncoder();
-
-    const writeSSE = async (data: string, event?: string) => {
-      try {
-        if (event) {
-          await writer.write(encoder.encode(`event: ${event}\n`));
-        }
-        await writer.write(encoder.encode(`data: ${data}\n\n`));
-      } catch {
-        // Silently handle write errors
-      }
-    };
-
-    const transport = new HonoSSETransport();
-    transport.attachStream({
-      writeSSE: async (data: { data: string; event?: string; id?: string }) => {
-        await writeSSE(data.data, data.event);
-      },
-      close: () => {
-        writer.close();
-      },
-    });
-
-    (async () => {
-      try {
-        const sessionServer = new McpServer(
-          {
-            name: "google-tasks-mcp",
-            version: "1.0.0",
-          },
-          {
-            capabilities: {
-              tools: {},
-            },
-          }
-        );
-
-        registerAllTools(sessionServer, mcpToken);
-
-        await sessionServer.connect(transport);
-
-        sessionManager.createSession(sessionId!, transport);
-        logger.info("MCP session established via POST");
-
-        await transport.handleIncomingMessage(message);
-
-        c.req.raw.signal.addEventListener("abort", () => {
-          logger.info("MCP connection closed by client");
-          sessionManager.deleteSession(sessionId!);
-        });
-
-        const heartbeat = setInterval(async () => {
-          try {
-            await writeSSE("", "ping");
-          } catch {
-            clearInterval(heartbeat);
-          }
-        }, 15000);
-
-        c.req.raw.signal.addEventListener("abort", () => {
-          clearInterval(heartbeat);
-          sessionManager.deleteSession(sessionId!);
-        });
-
-      } catch {
-        logger.error("Failed to initialize MCP session via POST");
-        sessionManager.deleteSession(sessionId!);
-        writer.close();
-      }
-    })();
-
-    const headers = {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      "Connection": "keep-alive",
-      "X-Accel-Buffering": "no",
-      "Mcp-Session-Id": sessionId,
-    };
-
-    return new Response(readable, { headers });
-  }
-
-  const session = sessionManager.getSession(sessionId);
-  if (!session) {
-    logger.warn("Message received for invalid or expired session");
-    return c.json({
-      error: "invalid_session",
-      error_description: "Session not found or expired"
-    }, 404);
-  }
-
-  try {
-    const message = await c.req.json() as JSONRPCMessage;
-
-    await session.transport.handleIncomingMessage(message);
-
-    return c.body(null, 202);
-  } catch {
-    logger.error("Failed to process incoming MCP message");
-    return c.json({
-      error: "internal_error",
-      error_description: "Failed to process message"
-    }, 500);
-  }
 }

--- a/src/server/mcp-endpoints.ts
+++ b/src/server/mcp-endpoints.ts
@@ -7,17 +7,7 @@ import { createLogger } from "../utils/logger.ts";
 
 const logger = createLogger({ component: "mcp-endpoints" });
 
-// Deno Deploy runs each request in a potentially different isolate, so MCP
-// session state cannot be shared in process memory across requests. The
-// server therefore operates in a stateless mode: every POST is fully
-// self contained. For each incoming JSON-RPC message we spin up a fresh
-// McpServer and transport, handle the single message, stream the response
-// back on the same HTTP response, and then close the stream.
-
 export function handleMcpGet(c: Context) {
-  // In stateless mode there is no long lived server initiated stream to
-  // resume, so a GET simply opens an empty SSE stream that stays quiet.
-  // Clients that probe GET will keep the connection idle without errors.
   const { readable, writable } = new TransformStream();
   const writer = writable.getWriter();
   const encoder = new TextEncoder();
@@ -80,7 +70,6 @@ export async function handleMcpPost(c: Context) {
       }
       await writer.write(encoder.encode(`data: ${data}\n\n`));
     } catch {
-      // Silently handle write errors
     }
   };
 
@@ -88,9 +77,6 @@ export async function handleMcpPost(c: Context) {
   transport.attachStream({
     writeSSE: async (data: { data: string; event?: string; id?: string }) => {
       await writeSSE(data.data, data.event);
-      // Each request expects a single response message. Once it has been
-      // written, close the stream so the client receives a complete reply
-      // instead of waiting on an open connection.
       closeStream();
     },
     close: () => {
@@ -119,8 +105,6 @@ export async function handleMcpPost(c: Context) {
 
       await transport.handleIncomingMessage(message);
 
-      // Notifications and responses without a reply will not trigger a
-      // write, so close the stream after a short delay to avoid hanging.
       setTimeout(() => {
         closeStream();
       }, 1000);


### PR DESCRIPTION
## What this fixes

The MCP transport kept session state in an in-memory `sessionManager`. On serverless or isolate-based hosts (such as Deno Deploy, which the README and SETUP recommend), each request can be handled by a different isolate, so the session created during the `initialize` POST is not visible to the follow-up `tools/list` POST. The result is that the connector authenticates successfully but then reports "This connector has no tools available," because `tools/list` runs against an isolate that has no record of the session.

## The change

`handleMcpPost` is rewritten to be stateless: it constructs a fresh transport and server per request rather than relying on a persisted session map, so it behaves correctly regardless of which isolate handles a given request. `handleMcpGet` is simplified accordingly. This keeps behavior identical on a single long-lived process while making it correct on isolate-based platforms.

## Verification

Deployed from a fork to Deno Deploy and connected as a custom connector in the Claude app. After this change the connector exposes all 14 Google Tasks tools, lists real task lists, and creates tasks end to end. Before the change, auth succeeded but no tools were exposed.

## Also included

A SETUP.md runbook documenting the full Google Cloud, Deno Deploy, and Claude connector setup for a single-user deployment. Happy to split this into a separate PR if you would prefer to keep the bugfix isolated; just let me know.

No secrets or credentials are included in this diff (placeholders only in the docs).